### PR TITLE
docs: Fastify SEO audit + @fastify/rate-limit comparison

### DIFF
--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -13,6 +13,7 @@ const footerLinks = {
   ],
   integrations: [
     { label: 'Express.js', href: '/docs/adapters/express' },
+    { label: 'Fastify', href: '/docs/adapters/fastify' },
     { label: 'Bun', href: '/docs/bun' },
     { label: 'NestJS', href: '/docs/adapters/nestjs' },
     { label: 'Node.js', href: '/docs/adapters/node' },

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -15,9 +15,9 @@ interface Props {
 const siteUrl = 'https://hitlimit.jointops.dev';
 
 const {
-  title = 'hitlimit - The Fastest Rate Limiter for Node.js, Bun, Express & NestJS | express-rate-limit alternative',
-  description = 'Lightning-fast rate limiting middleware for Node.js, Bun, Express, NestJS, and Elysia. A faster, lighter alternative to express-rate-limit and rate-limiter-flexible. Sub-millisecond performance, memory/SQLite/Redis stores, zero config.',
-  keywords = 'rate limit, rate limiter, rate limiting, express rate limit, express-rate-limit, express-rate-limit alternative, rate-limiter-flexible, rate-limiter-flexible alternative, express middleware, nestjs rate limit, nestjs throttler, @nestjs/throttler, bun rate limit, bun rate limiter, elysia rate limit, elysia plugin, nodejs rate limiter, node rate limit, api rate limiting, throttle requests, request throttling, ddos protection, brute force protection, login protection, redis rate limit, sqlite rate limit, api throttling, request limiting, npm rate limit, sliding window, fixed window, token bucket, api security, request limiter',
+  title = 'hitlimit - The Fastest Rate Limiter for Node.js, Bun, Express, Fastify & NestJS | express-rate-limit alternative',
+  description = 'Lightning-fast rate limiting middleware for Node.js, Bun, Express, Fastify, NestJS, and Elysia. A faster, lighter alternative to express-rate-limit, @fastify/rate-limit, and rate-limiter-flexible. Sub-millisecond performance, memory/SQLite/Redis stores, zero config.',
+  keywords = 'rate limit, rate limiter, rate limiting, express rate limit, express-rate-limit, express-rate-limit alternative, fastify rate limit, fastify rate limiter, fastify plugin, @fastify/rate-limit, @fastify/rate-limit alternative, rate-limiter-flexible, rate-limiter-flexible alternative, express middleware, nestjs rate limit, nestjs throttler, @nestjs/throttler, bun rate limit, bun rate limiter, elysia rate limit, elysia plugin, nodejs rate limiter, node rate limit, api rate limiting, throttle requests, request throttling, ddos protection, brute force protection, login protection, redis rate limit, sqlite rate limit, api throttling, request limiting, npm rate limit, sliding window, fixed window, token bucket, api security, request limiter',
   canonical = `${siteUrl}${Astro.url.pathname}`,
   ogType = 'website'
 } = Astro.props;

--- a/docs/src/pages/compare/index.astro
+++ b/docs/src/pages/compare/index.astro
@@ -4,8 +4,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 
 <BaseLayout
   title="Rate Limiter Comparison - hitlimit vs Alternatives (2026)"
-  description="Compare hitlimit with express-rate-limit, rate-limiter-flexible, and @nestjs/throttler. See benchmarks, features, and migration guides."
-  keywords="rate limiter comparison, express-rate-limit alternative, rate-limiter-flexible alternative, nestjs throttler alternative, best nodejs rate limiter, fastest rate limiter"
+  description="Compare hitlimit with express-rate-limit, @fastify/rate-limit, rate-limiter-flexible, and @nestjs/throttler. See benchmarks, features, and migration guides."
+  keywords="rate limiter comparison, express-rate-limit alternative, @fastify/rate-limit alternative, fastify rate limit alternative, rate-limiter-flexible alternative, nestjs throttler alternative, best nodejs rate limiter, fastest rate limiter"
 >
   <section class="py-20 px-4">
     <div class="max-w-4xl mx-auto">
@@ -124,6 +124,40 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
             </svg>
           </div>
         </a>
+        <!-- @fastify/rate-limit -->
+        <a href="/docs/comparison#vs-fastify-rate-limit" class="comparison-card group">
+          <div class="card-content">
+            <div class="card-header">
+              <h2 class="text-xl font-semibold group-hover:text-[var(--color-accent)] transition-colors">
+                hitlimit vs @fastify/rate-limit
+              </h2>
+              <span class="badge">Fastify Official</span>
+            </div>
+            <p class="text-[var(--color-text-secondary)] mb-4">
+              The official Fastify rate limiter plugin.
+              hitlimit offers built-in tiered limits, SQLite store, and works across all frameworks.
+            </p>
+            <div class="stats-row">
+              <div class="stat">
+                <span class="stat-value good">2x</span>
+                <span class="stat-label">Smaller</span>
+              </div>
+              <div class="stat">
+                <span class="stat-value good">Built-in</span>
+                <span class="stat-label">Tiered Limits</span>
+              </div>
+              <div class="stat">
+                <span class="stat-value">~7KB</span>
+                <span class="stat-label">vs ~15KB</span>
+              </div>
+            </div>
+          </div>
+          <div class="card-arrow">
+            <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M9 5l7 7-7 7" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
+        </a>
       </div>
 
       <!-- Quick Summary -->
@@ -151,6 +185,12 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
                 <td>~66KB</td>
                 <td>1.22M ops/s</td>
                 <td>Memory only</td>
+              </tr>
+              <tr>
+                <td>@fastify/rate-limit</td>
+                <td>~15KB</td>
+                <td>N/A</td>
+                <td>Memory, Redis</td>
               </tr>
               <tr>
                 <td>rate-limiter-flexible</td>

--- a/docs/src/pages/docs/adapters/fastify.astro
+++ b/docs/src/pages/docs/adapters/fastify.astro
@@ -132,6 +132,69 @@ app.<span class="fn">register</span>(<span class="kw">async</span> (scope) => {"
 {"}"})</code></pre>
   </div>
 
+  <h2 id="migrating">Migrating from @fastify/rate-limit</h2>
+
+  <p>Switching from <code>@fastify/rate-limit</code> to hitlimit is straightforward. Both use Fastify's plugin system.</p>
+
+  <div class="code-block">
+    <div class="code-header"><span class="code-label">Before (@fastify/rate-limit)</span></div>
+    <pre><code><span class="kw">import</span> rateLimit <span class="kw">from</span> <span class="str">'@fastify/rate-limit'</span>
+
+<span class="kw">await</span> app.<span class="fn">register</span>(rateLimit, {"{"}
+  max: <span class="num">100</span>,
+  timeWindow: <span class="str">'1 minute'</span>
+{"}"})</code></pre>
+  </div>
+
+  <div class="code-block">
+    <div class="code-header"><span class="code-label">After (hitlimit)</span></div>
+    <pre><code><span class="kw">import</span> {"{"} hitlimit {"}"} <span class="kw">from</span> <span class="str">'@joint-ops/hitlimit/fastify'</span>
+
+<span class="kw">await</span> app.<span class="fn">register</span>(hitlimit, {"{"}
+  limit: <span class="num">100</span>,
+  window: <span class="str">'1m'</span>
+{"}"})</code></pre>
+  </div>
+
+  <div class="migration-table">
+    <table>
+      <thead>
+        <tr>
+          <th>@fastify/rate-limit</th>
+          <th>hitlimit</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>max: 100</code></td>
+          <td><code>limit: 100</code></td>
+        </tr>
+        <tr>
+          <td><code>timeWindow: '1 minute'</code></td>
+          <td><code>window: '1m'</code></td>
+        </tr>
+        <tr>
+          <td><code>keyGenerator: (req) => ...</code></td>
+          <td><code>key: (req) => ...</code></td>
+        </tr>
+        <tr>
+          <td><code>errorResponseBuilder: (req, ctx) => ...</code></td>
+          <td><code>response: (info) => ...</code></td>
+        </tr>
+        <tr>
+          <td>No built-in tiered limits</td>
+          <td><code>tiers: {"{"} free: ..., pro: ... {"}"}</code></td>
+        </tr>
+        <tr>
+          <td>No built-in SQLite store</td>
+          <td><code>store: sqliteStore()</code></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>See the <a href="/docs/comparison#vs-fastify-rate-limit">full comparison</a> for more details.</p>
+
   <h2 id="next-steps">Next Steps</h2>
 
   <ul>
@@ -148,4 +211,10 @@ app.<span class="fn">register</span>(<span class="kw">async</span> (scope) => {"
   .code-block pre { margin: 0; padding: 1rem; overflow-x: auto; font-family: var(--font-mono); font-size: 0.875rem; line-height: 1.7; }
   .code-block code { background: none !important; border: none !important; padding: 0 !important; }
   .kw { color: #c792ea; } .str { color: #a6e22e; } .num { color: #fd971f; } .fn { color: #66d9ef; } .cm { color: #71717a; }
+  .migration-table { margin: 1.5rem 0; overflow-x: auto; }
+  .migration-table table { width: 100%; border-collapse: separate; border-spacing: 0; border: 1px solid var(--color-border); border-radius: 0.75rem; overflow: hidden; font-size: 0.875rem; }
+  .migration-table th { background: var(--color-bg-surface); text-align: left; padding: 0.75rem 1rem; font-weight: 600; color: var(--color-text-muted); border-bottom: 1px solid var(--color-border); }
+  .migration-table td { padding: 0.75rem 1rem; border-bottom: 1px solid var(--color-border); color: var(--color-text-secondary); }
+  .migration-table tr:last-child td { border-bottom: none; }
+  .migration-table code { background: var(--color-bg-elevated); color: var(--color-accent); padding: 0.2em 0.4em; border-radius: 4px; font-size: 0.875em; }
 </style>

--- a/docs/src/pages/docs/comparison.astro
+++ b/docs/src/pages/docs/comparison.astro
@@ -59,9 +59,9 @@ const faqSchema = {
 ---
 
 <DocsLayout
-  title="hitlimit vs express-rate-limit vs rate-limiter-flexible | Comparison Guide"
-  description="Compare hitlimit with express-rate-limit, rate-limiter-flexible, and @nestjs/throttler. Feature comparison, performance benchmarks, and migration guides."
-  keywords="hitlimit vs express-rate-limit, best rate limiter nodejs, rate-limiter-flexible alternative, nestjs throttler comparison, fastest rate limiter, rate limit comparison, express rate limit alternative, bun rate limiter"
+  title="hitlimit vs express-rate-limit vs @fastify/rate-limit vs rate-limiter-flexible | Comparison Guide"
+  description="Compare hitlimit with express-rate-limit, @fastify/rate-limit, rate-limiter-flexible, and @nestjs/throttler. Feature comparison, performance benchmarks, and migration guides."
+  keywords="hitlimit vs express-rate-limit, hitlimit vs fastify rate limit, best rate limiter nodejs, rate-limiter-flexible alternative, nestjs throttler comparison, fastest rate limiter, rate limit comparison, express rate limit alternative, fastify rate limit alternative, bun rate limiter"
 >
   <!-- FAQPage Schema for AI Search -->
   <script type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
@@ -82,6 +82,7 @@ const faqSchema = {
           <th>Feature</th>
           <th class="highlight-col">hitlimit</th>
           <th>express-rate-limit</th>
+          <th>@fastify/rate-limit</th>
           <th>rate-limiter-flexible</th>
           <th>@nestjs/throttler</th>
         </tr>
@@ -91,6 +92,7 @@ const faqSchema = {
           <td>Bundle Size</td>
           <td class="highlight-col good">~7KB</td>
           <td>~66KB</td>
+          <td>~15KB</td>
           <td>~155KB</td>
           <td>~22KB</td>
         </tr>
@@ -98,6 +100,7 @@ const faqSchema = {
           <td>Zero Dependencies</td>
           <td class="highlight-col good">Yes</td>
           <td>No</td>
+          <td>No (3 deps)</td>
           <td>No</td>
           <td>No</td>
         </tr>
@@ -105,6 +108,7 @@ const faqSchema = {
           <td>TypeScript</td>
           <td class="highlight-col good">Native</td>
           <td>@types</td>
+          <td>Native</td>
           <td>@types</td>
           <td>Native</td>
         </tr>
@@ -114,11 +118,13 @@ const faqSchema = {
           <td>Yes</td>
           <td>Yes</td>
           <td>Yes</td>
+          <td>Yes</td>
         </tr>
         <tr>
           <td>Memory Store (high-traffic)</td>
           <td class="highlight-col good">2.3M ops/s</td>
           <td>1.2M ops/s</td>
+          <td>N/A</td>
           <td>1.6M ops/s</td>
           <td>N/A</td>
         </tr>
@@ -128,11 +134,13 @@ const faqSchema = {
           <td>External</td>
           <td>No</td>
           <td>No</td>
+          <td>No</td>
         </tr>
         <tr>
           <td>Redis Store</td>
           <td class="highlight-col">Built-in</td>
           <td>External</td>
+          <td>Built-in</td>
           <td>Built-in</td>
           <td>External</td>
         </tr>
@@ -142,11 +150,13 @@ const faqSchema = {
           <td>No</td>
           <td>No</td>
           <td>No</td>
+          <td>No</td>
         </tr>
         <tr>
           <td>Express</td>
           <td class="highlight-col good">Yes</td>
           <td>Yes</td>
+          <td>No</td>
           <td>Yes</td>
           <td>Via adapter</td>
         </tr>
@@ -154,6 +164,7 @@ const faqSchema = {
           <td>Fastify</td>
           <td class="highlight-col good">Native</td>
           <td>No</td>
+          <td class="good">Native</td>
           <td>Yes</td>
           <td>No</td>
         </tr>
@@ -161,6 +172,7 @@ const faqSchema = {
           <td>NestJS</td>
           <td class="highlight-col good">Native</td>
           <td>Via wrapper</td>
+          <td>No</td>
           <td>Yes</td>
           <td>Native</td>
         </tr>
@@ -170,11 +182,13 @@ const faqSchema = {
           <td>No</td>
           <td>No</td>
           <td>No</td>
+          <td>No</td>
         </tr>
         <tr>
           <td>Human-readable Windows</td>
           <td class="highlight-col good">'1m', '1h'</td>
           <td>ms only</td>
+          <td>'1 minute'</td>
           <td>seconds</td>
           <td>seconds</td>
         </tr>
@@ -182,6 +196,7 @@ const faqSchema = {
           <td>Tiered Limits</td>
           <td class="highlight-col good">Built-in</td>
           <td>Manual</td>
+          <td>Via dynamic max</td>
           <td>Manual</td>
           <td>Manual</td>
         </tr>
@@ -320,6 +335,55 @@ const faqSchema = {
 {"}"})</code></pre>
   </div>
 
+  <h2 id="vs-fastify-rate-limit">hitlimit vs @fastify/rate-limit</h2>
+
+  <p>
+    <strong>@fastify/rate-limit</strong> is the official Fastify rate limiter plugin maintained by the Fastify team.
+    It's the default choice for Fastify-only projects.
+  </p>
+
+  <div class="comparison-box">
+    <h3>Choose hitlimit if you need:</h3>
+    <ul>
+      <li>Built-in tiered rate limits (Free/Pro/Enterprise tiers in 8 lines)</li>
+      <li>Per-request error handling (<code>onStoreError</code> callback)</li>
+      <li>Built-in SQLite store for persistence without Redis</li>
+      <li>Same library across Express, Fastify, NestJS, and Bun</li>
+      <li>Zero runtime dependencies (~7KB vs ~15KB)</li>
+      <li>Bun runtime support</li>
+    </ul>
+
+    <h3>Choose @fastify/rate-limit if you need:</h3>
+    <ul>
+      <li>Official Fastify team maintenance and support</li>
+      <li>Ban threshold for repeat offenders</li>
+      <li>IP allowList built-in</li>
+      <li>Fastify-only project (tighter integration)</li>
+    </ul>
+  </div>
+
+  <h3>Migration from @fastify/rate-limit</h3>
+
+  <div class="code-block">
+    <div class="code-header"><span class="code-label">Before (@fastify/rate-limit)</span></div>
+    <pre><code><span class="kw">import</span> rateLimit <span class="kw">from</span> <span class="str">'@fastify/rate-limit'</span>
+
+<span class="kw">await</span> app.<span class="fn">register</span>(rateLimit, {"{"}
+  max: <span class="num">100</span>,
+  timeWindow: <span class="str">'1 minute'</span>
+{"}"})</code></pre>
+  </div>
+
+  <div class="code-block">
+    <div class="code-header"><span class="code-label">After (hitlimit)</span></div>
+    <pre><code><span class="kw">import</span> {"{"} hitlimit {"}"} <span class="kw">from</span> <span class="str">'@joint-ops/hitlimit/fastify'</span>
+
+<span class="kw">await</span> app.<span class="fn">register</span>(hitlimit, {"{"}
+  limit: <span class="num">100</span>,
+  window: <span class="str">'1m'</span>
+{"}"})</code></pre>
+  </div>
+
   <h2 id="performance">Performance Comparison</h2>
 
   <p>High-traffic scenario (10,000 unique IPs) - where hitlimit excels.</p>
@@ -416,6 +480,14 @@ const faqSchema = {
         <tr>
           <td>Bundle size matters</td>
           <td class="good">hitlimit - Smallest option (~7KB)</td>
+        </tr>
+        <tr>
+          <td>New Fastify project</td>
+          <td class="good">hitlimit - Tiered limits + multi-framework</td>
+        </tr>
+        <tr>
+          <td>Fastify-only, need ban/allowList</td>
+          <td>@fastify/rate-limit - Official plugin, tighter integration</td>
         </tr>
         <tr>
           <td>Need Redis clustering</td>

--- a/docs/src/pages/docs/examples/index.astro
+++ b/docs/src/pages/docs/examples/index.astro
@@ -4,8 +4,8 @@ import DocsLayout from '../../../layouts/DocsLayout.astro';
 
 <DocsLayout
   title="Real-World Examples - hitlimit | Production Rate Limiting Patterns"
-  description="Production-ready rate limiting examples for SaaS, e-commerce, authentication, social platforms, and gaming backends. Copy-paste code for Express, NestJS, Bun, and Elysia."
-  keywords="rate limit examples, express rate limit example, nestjs rate limit example, api rate limiting patterns, production rate limiting, saas rate limit, ecommerce rate limit"
+  description="Production-ready rate limiting examples for SaaS, e-commerce, authentication, social platforms, and gaming backends. Copy-paste code for Express, Fastify, NestJS, Bun, and Elysia."
+  keywords="rate limit examples, express rate limit example, fastify rate limit example, fastify rate limiter example, nestjs rate limit example, api rate limiting patterns, production rate limiting, saas rate limit, ecommerce rate limit"
 >
   <h1>Real-World Examples</h1>
 
@@ -23,6 +23,13 @@ import DocsLayout from '../../../layouts/DocsLayout.astro';
     <pre><code><span class="kw">import</span> {"{"} hitlimit {"}"} <span class="kw">from</span> <span class="str">'@joint-ops/hitlimit'</span>
 
 app.<span class="fn">use</span>(<span class="fn">hitlimit</span>()) <span class="cm">// 100 requests per minute per IP</span></code></pre>
+  </div>
+
+  <div class="code-block">
+    <div class="code-header"><span class="code-label">Fastify - One Liner</span></div>
+    <pre><code><span class="kw">import</span> {"{"} hitlimit {"}"} <span class="kw">from</span> <span class="str">'@joint-ops/hitlimit/fastify'</span>
+
+<span class="kw">await</span> app.<span class="fn">register</span>(hitlimit, {"{"} limit: <span class="num">100</span>, window: <span class="str">'1m'</span> {"}"}) <span class="cm">// 100 req/min per IP</span></code></pre>
   </div>
 
   <div class="code-block">

--- a/docs/src/pages/docs/index.astro
+++ b/docs/src/pages/docs/index.astro
@@ -3,9 +3,9 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
 ---
 
 <DocsLayout
-  title="hitlimit Documentation - Fast Rate Limiting for Node.js, Bun, Express & NestJS"
-  description="Complete guide to hitlimit rate limiter. Learn how to protect your APIs with high-performance rate limiting middleware for Express, NestJS, Bun, and Elysia. 200K+ req/s with memory, SQLite, or Redis stores."
-  keywords="hitlimit documentation, rate limit tutorial, express rate limit middleware, nestjs throttler alternative, bun rate limiter, elysia rate limit, nodejs api protection, api rate limiting guide, redis rate limit, sqlite rate limit, brute force protection"
+  title="hitlimit Documentation - Fast Rate Limiting for Node.js, Bun, Express, Fastify & NestJS"
+  description="Complete guide to hitlimit rate limiter. Learn how to protect your APIs with high-performance rate limiting middleware for Express, Fastify, NestJS, Bun, and Elysia. 200K+ req/s with memory, SQLite, or Redis stores."
+  keywords="hitlimit documentation, rate limit tutorial, express rate limit middleware, fastify rate limit plugin, fastify rate limiter, @fastify/rate-limit alternative, nestjs throttler alternative, bun rate limiter, elysia rate limit, nodejs api protection, api rate limiting guide, redis rate limit, sqlite rate limit, brute force protection"
 >
   <h1>Welcome to hitlimit</h1>
 
@@ -35,7 +35,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
         </svg>
       </div>
       <h3>Universal</h3>
-      <p>Works with Express, NestJS, Bun.serve, Elysia, and raw Node.js HTTP. One API, any framework.</p>
+      <p>Works with Express, Fastify, NestJS, Bun.serve, Elysia, and raw Node.js HTTP. One API, any framework.</p>
     </div>
 
     <div class="feature-card cyan">

--- a/docs/src/pages/docs/quick-start.astro
+++ b/docs/src/pages/docs/quick-start.astro
@@ -4,8 +4,8 @@ import DocsLayout from '../../layouts/DocsLayout.astro';
 
 <DocsLayout
   title="Rate Limiting Quick Start Guide - hitlimit | Get Started in 5 Minutes"
-  description="Quick start guide for hitlimit rate limiter. Learn how to set up API rate limiting in Express, NestJS, Bun, and Elysia in under 5 minutes with code examples."
-  keywords="rate limit tutorial, api rate limiting guide, express rate limit tutorial, nodejs rate limit example, rate limiter setup, quick start rate limiting, api throttling guide"
+  description="Quick start guide for hitlimit rate limiter. Learn how to set up API rate limiting in Express, Fastify, NestJS, Bun, and Elysia in under 5 minutes with code examples."
+  keywords="rate limit tutorial, api rate limiting guide, express rate limit tutorial, fastify rate limit tutorial, fastify rate limiter setup, nodejs rate limit example, rate limiter setup, quick start rate limiting, api throttling guide"
 >
   <h1>Quick Start</h1>
 
@@ -30,6 +30,24 @@ app.<span class="fn">get</span>(<span class="str">'/api/data'</span>, (req, res)
 {"}"})
 
 app.<span class="fn">listen</span>(<span class="num">3000</span>)</code></pre>
+  </div>
+
+  <h2 id="fastify">Fastify</h2>
+
+  <p>Using Fastify? Register hitlimit as a plugin:</p>
+
+  <div class="code-block">
+    <div class="code-header"><span class="code-label">app.ts</span></div>
+    <pre><code><span class="kw">import</span> Fastify <span class="kw">from</span> <span class="str">'fastify'</span>
+<span class="kw">import</span> {"{"} hitlimit {"}"} <span class="kw">from</span> <span class="str">'@joint-ops/hitlimit/fastify'</span>
+
+<span class="kw">const</span> app = <span class="fn">Fastify</span>()
+
+<span class="cm">// 100 requests per minute per IP</span>
+<span class="kw">await</span> app.<span class="fn">register</span>(hitlimit, {"{"} limit: <span class="num">100</span>, window: <span class="str">'1m'</span> {"}"})
+
+app.<span class="fn">get</span>(<span class="str">'/'</span>, () => <span class="str">'Hello!'</span>)
+<span class="kw">await</span> app.<span class="fn">listen</span>({"{"} port: <span class="num">3000</span> {"}"})</code></pre>
   </div>
 
   <h2 id="time-windows">Time Windows</h2>
@@ -91,6 +109,7 @@ Retry-After: 27  <span class="cm">(only when rate limited)</span></code></pre>
     <li><a href="/docs/configuration/options">Configuration Options</a> - All available options</li>
     <li><a href="/docs/stores/overview">Stores</a> - Memory, SQLite, Redis</li>
     <li><a href="/docs/adapters/express">Express Adapter</a> - Express.js integration</li>
+    <li><a href="/docs/adapters/fastify">Fastify Adapter</a> - Fastify plugin integration</li>
   </ul>
 </DocsLayout>
 

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -10,9 +10,9 @@ import CTA from '../components/CTA.astro';
 ---
 
 <BaseLayout
-  title="hitlimit - Fastest Rate Limiter for Node.js & Bun | express-rate-limit Alternative"
-  description="High-performance rate limiting middleware for Express, NestJS, Bun & Elysia. 2x faster than express-rate-limit, 10x smaller bundle (~7KB). Tiered limits, Redis/SQLite stores, zero config. The modern alternative to express-rate-limit and rate-limiter-flexible."
-  keywords="rate limit, rate limiter, express-rate-limit alternative, rate-limiter-flexible alternative, nodejs rate limit, bun rate limit, express rate limit, nestjs throttler, elysia rate limit, api rate limiting, ddos protection, brute force protection"
+  title="hitlimit - Fastest Rate Limiter for Node.js & Bun | Express, Fastify, NestJS | express-rate-limit Alternative"
+  description="High-performance rate limiting middleware for Express, Fastify, NestJS, Bun & Elysia. 2x faster than express-rate-limit, 10x smaller bundle (~7KB). Tiered limits, Redis/SQLite stores, zero config. The modern alternative to express-rate-limit, @fastify/rate-limit, and rate-limiter-flexible."
+  keywords="rate limit, rate limiter, express-rate-limit alternative, @fastify/rate-limit alternative, fastify rate limit, fastify rate limiter, fastify plugin, rate-limiter-flexible alternative, nodejs rate limit, bun rate limit, express rate limit, nestjs throttler, elysia rate limit, api rate limiting, ddos protection, brute force protection"
 >
   <Hero />
   <Features />

--- a/packages/hitlimit/README.md
+++ b/packages/hitlimit/README.md
@@ -404,6 +404,18 @@ import { hitlimit } from '@joint-ops/hitlimit'
 app.use(hitlimit({ limit: 100, window: '1m' }))
 ```
 
+### From @fastify/rate-limit
+
+```typescript
+// Before (@fastify/rate-limit)
+import rateLimit from '@fastify/rate-limit'
+await app.register(rateLimit, { max: 100, timeWindow: '1 minute' })
+
+// After (hitlimit) - tiered limits, SQLite, multi-framework
+import { hitlimit } from '@joint-ops/hitlimit/fastify'
+await app.register(hitlimit, { limit: 100, window: '1m' })
+```
+
 ### From @nestjs/throttler
 
 ```typescript


### PR DESCRIPTION
## Summary
- Deep SEO audit: added Fastify to all meta tags (title, description, keywords) across landing page, docs index, footer, quick-start, examples, and comparison pages
- Added @fastify/rate-limit comparison card and summary table row to the compare landing page
- Added @fastify/rate-limit vs hitlimit comparison section with migration guide to comparison docs
- Added "Migrating from @fastify/rate-limit" section to Fastify adapter page
- Added @fastify/rate-limit migration example to README

## Files Changed
- `layouts/BaseLayout.astro` — Default SEO meta now includes Fastify
- `pages/index.astro` — Landing page SEO includes Fastify + @fastify/rate-limit
- `pages/docs/index.astro` — Docs landing SEO + "Universal" card lists Fastify
- `components/Footer.astro` — Fastify added to integrations links
- `pages/docs/quick-start.astro` — Fastify code example + SEO meta
- `pages/docs/examples/index.astro` — Fastify one-liner + SEO meta
- `pages/compare/index.astro` — @fastify/rate-limit card + table row
- `pages/docs/comparison.astro` — @fastify/rate-limit column + vs section + migration
- `pages/docs/adapters/fastify.astro` — Migration from @fastify/rate-limit section
- `packages/hitlimit/README.md` — @fastify/rate-limit migration example

## Test plan
- [x] `pnpm docs:build` — 48 pages, 0 errors
- [x] Verify all internal links resolve correctly
- [x] Visual check on landing, compare, quick-start, examples pages